### PR TITLE
Added support for setting correlation id to null

### DIFF
--- a/pulsar-jms-integration-tests/pom.xml
+++ b/pulsar-jms-integration-tests/pom.xml
@@ -97,8 +97,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-${project.version}-nar.nar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/pom.xml
+++ b/pulsar-jms/pom.xml
@@ -122,8 +122,8 @@
             <configuration>
               <tasks>
                 <echo>copy filters</echo>
-                <mkdir dir="${project.build.outputDirectory}/filters" />
-                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar" />
+                <mkdir dir="${project.build.outputDirectory}/filters"/>
+                <copy verbose="true" file="${basedir}/../pulsar-jms-filters/target/pulsar-jms-filters-${project.version}.jar" tofile="${project.build.outputDirectory}/filters/jms-filter.nar"/>
               </tasks>
             </configuration>
           </execution>

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessage.java
@@ -262,7 +262,11 @@ public abstract class PulsarMessage implements Message {
    */
   @Override
   public void setJMSCorrelationID(String correlationID) throws JMSException {
-    this.correlationId = correlationID.getBytes(StandardCharsets.UTF_8);
+    if (correlationID != null) {
+      this.correlationId = correlationID.getBytes(StandardCharsets.UTF_8);
+    } else {
+      this.correlationId = null;
+    }
   }
 
   /**


### PR DESCRIPTION
As part of the JMS compatibility testing, I discovered that the ability to set the correlationId property to null must be supported, and the current code did not.

This PR fixes that.