### PR TITLE
Added delay for Pulsar metadata

### DIFF
--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarConnectionFactory.java
@@ -999,6 +999,8 @@ public class PulsarConnectionFactory
       } catch (Exception ignore) {
         // ignore
         Utils.handleException(ignore);
+      } finally {
+        this.unregisterConnection(con);
       }
     }
 

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarMessageProducer.java
@@ -860,6 +860,9 @@ class PulsarMessageProducer implements MessageProducer, TopicPublisher, QueueSen
       // res.setJMSExpiration(message.getJMSExpiration());
     } else {
       res = (PulsarMessage) message;
+      res.setJMSMessageID(null);
+      res.setJMSTimestamp(0);
+      res.setJMSExpiration(0);
     }
     res.setWritable(true);
     res.setStringProperty("JMSConnectionID", session.getConnection().getConnectionId());

--- a/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTemporaryDestination.java
+++ b/pulsar-jms/src/main/java/com/datastax/oss/pulsar/jms/PulsarTemporaryDestination.java
@@ -15,10 +15,12 @@
  */
 package com.datastax.oss.pulsar.jms;
 
+import javax.jms.IllegalStateException;
 import javax.jms.InvalidDestinationException;
 import javax.jms.JMSException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
 import org.apache.pulsar.common.policies.data.TopicStats;
 
 @Slf4j
@@ -44,15 +46,6 @@ abstract class PulsarTemporaryDestination extends PulsarDestination {
       log.info("Deleting {}", this);
       String topicName = getInternalTopicName();
       String fullQualifiedTopicName = session.getFactory().applySystemNamespace(topicName);
-      TopicStats stats =
-          session.getFactory().getPulsarAdmin().topics().getStats(fullQualifiedTopicName);
-      log.info("Stats {}", stats);
-
-      int numConsumers =
-          stats.getSubscriptions().values().stream().mapToInt(s -> s.getConsumers().size()).sum();
-      if (numConsumers > 0) {
-        throw new JMSException("Cannot delete a temporary destination with active consumers");
-      }
 
       if (session
           .getFactory()
@@ -61,19 +54,30 @@ abstract class PulsarTemporaryDestination extends PulsarDestination {
           .getPartitionedTopicList(session.getFactory().getSystemNamespace())
           .stream()
           .anyMatch(t -> t.equals(fullQualifiedTopicName))) {
-        session
-            .getFactory()
-            .getPulsarAdmin()
-            .topics()
-            .deletePartitionedTopic(
-                fullQualifiedTopicName, session.getFactory().isForceDeleteTemporaryDestinations());
+
+        if (getNumberOfActiveConsumers(fullQualifiedTopicName, true) > 0) {
+          throw new JMSException("Cannot delete a temporary destination with active consumers");
+        } else {
+          session
+              .getFactory()
+              .getPulsarAdmin()
+              .topics()
+              .deletePartitionedTopic(
+                  fullQualifiedTopicName,
+                  session.getFactory().isForceDeleteTemporaryDestinations());
+        }
       } else {
-        session
-            .getFactory()
-            .getPulsarAdmin()
-            .topics()
-            .delete(
-                fullQualifiedTopicName, session.getFactory().isForceDeleteTemporaryDestinations());
+        if (getNumberOfActiveConsumers(fullQualifiedTopicName, false) > 0) {
+          throw new JMSException("Cannot delete a temporary destination with active consumers");
+        } else {
+          session
+              .getFactory()
+              .getPulsarAdmin()
+              .topics()
+              .delete(
+                  fullQualifiedTopicName,
+                  session.getFactory().isForceDeleteTemporaryDestinations());
+        }
       }
 
     } catch (final PulsarAdminException paEx) {
@@ -81,5 +85,53 @@ abstract class PulsarTemporaryDestination extends PulsarDestination {
     } finally {
       session.getConnection().removeTemporaryDestination(this);
     }
+  }
+
+  /**
+   * To account for lag in the Pulsar Admin metadata, this method will wait a total of 3 seconds for
+   * any consumers to be removed from the topic before returning the final count.
+   *
+   * @param topic
+   * @param partitionedTopic
+   * @return
+   * @throws IllegalStateException
+   * @throws PulsarAdminException
+   */
+  private int getNumberOfActiveConsumers(String topic, boolean partitionedTopic)
+      throws IllegalStateException, PulsarAdminException {
+    int numConsumers, numAttempts = 0;
+
+    do {
+      if (partitionedTopic) {
+        PartitionedTopicStats partitionedStats =
+            session.getFactory().getPulsarAdmin().topics().getPartitionedStats(topic, true);
+
+        log.info("Partition Stats {}", partitionedStats);
+        numConsumers =
+            partitionedStats
+                .getSubscriptions()
+                .values()
+                .stream()
+                .mapToInt(s -> s.getConsumers().size())
+                .sum();
+
+      } else {
+        TopicStats stats = session.getFactory().getPulsarAdmin().topics().getStats(topic);
+        log.info("Stats {}", stats);
+        numConsumers =
+            stats.getSubscriptions().values().stream().mapToInt(s -> s.getConsumers().size()).sum();
+      }
+
+      if (numConsumers > 0) {
+        try {
+          Thread.sleep(1000);
+        } catch (final InterruptedException ex) {
+          // Ignore these
+        }
+      }
+
+    } while (numConsumers > 0 && numAttempts++ < 3);
+
+    return numConsumers;
   }
 }


### PR DESCRIPTION
Fixes for the following Failures/Errors:

FIXED: A new JMSMessageID wasn't allocated for the resent message
FIXED: Allocated JMSMessageID is not unique
FIXED: Duplicate JMSMessageID allocated expected:<10> but was:<1>
FIXED: AssertionFailedError: Received message has different properties to that sent
FIXED: AssertionFailedError: A new JMSMessageID wasn't allocated for the resent message